### PR TITLE
Added unobtrusive hooking functionality via the debugUI.hookCallbacks()

### DIFF
--- a/debugUI/init.lua
+++ b/debugUI/init.lua
@@ -42,6 +42,63 @@ debugUI.draw = function()
 	debugUI.loveframes.draw()
 end
 
+debugUI.hookCallbacks = function()
+	-- Hook into the love callback functions we need.
+	-- These variable names will show up in error traces,
+	-- so we prefix them with something descriptive to
+	-- hopefully avoid confusion for users who are debugging.
+
+	local debugUI_hooked_love_update = love.update
+	local debugUI_hooked_love_draw = love.draw
+	local debugUI_hooked_love_mousepressed = love.mousepressed
+	local debugUI_hooked_love_mousereleased = love.mousereleased
+	local debugUI_hooked_love_keypressed = love.keypressed
+	local debugUI_hooked_love_keyreleased = love.keyreleased
+
+	-- We wrap the users original functions, calling our
+	-- own callbacks afterwards. We need to check whether
+	-- any given function is defined before calling it, and
+	-- for future compatibility, we preserve parameters and
+	-- return values exactly.
+	love.update = function(...)
+		local ret
+		if debugUI_hooked_love_update then ret = debugUI_hooked_love_update(...) end
+		debugUI.update(...)
+		return ret
+	end
+	love.draw = function(...)
+		local ret
+		if debugUI_hooked_love_draw then ret = debugUI_hooked_love_draw(...) end
+		debugUI.draw(...)
+		return ret
+	end
+	love.mousepressed = function(...)
+		local ret
+		if debugUI_hooked_love_mousepressed then ret = debugUI_hooked_love_mousepressed(...) end
+		debugUI.mousepressed(...)
+		return ret
+	end
+	love.mousereleased = function(...)
+		local ret
+		if debugUI_hooked_love_mousereleased then ret = debugUI_hooked_love_mousereleased(...) end
+		debugUI.mousereleased(...)
+		return ret
+	end
+	love.keypressed = function(...)
+		local ret
+		if debugUI_hooked_love_keypressed then ret = debugUI_hooked_love_keypressed(...) end
+		debugUI.keypressed(...)
+		return ret
+	end
+	love.keyreleased = function(...)
+		local ret
+		if debugUI_hooked_love_keyreleased then ret = debugUI_hooked_love_keyreleased(...) end
+		debugUI.keyreleased(...)
+		return ret
+	end
+
+end
+
 debugUI.new = function(t, maxheight, wname,...)
 	local args = {...}
 

--- a/main.lua
+++ b/main.lua
@@ -1,5 +1,3 @@
-
-
 function love.load()
 	require "debugUI"
 	test = {super = 3}
@@ -21,15 +19,14 @@ function love.load()
 		{var = "testc", name = "testb", type = "checkbox",val = true}},
 		{{var = "argh", type = "dropdown", vals = {"a","b","c"}}}
 	
-	},300,"Options","sliders","checkboxes","dropdowns")
+	}, 300, "Options", "sliders", "checkboxes", "dropdowns")
 	b = debugUI.new(
-	{var = "col", name = "background color", type="color"}
-	)
+		{var = "col", name = "background color", type="color"})
 	col[2] = 100
+	debugUI.hookCallbacks()
 end
 
 function love.update(dt)
-	debugUI.update(dt)
 	test.super = (test.super + 50*dt)%100
 	love.graphics.setBackgroundColor(col)
 	col[1] = (col[1] + 100*dt)%256
@@ -40,23 +37,8 @@ function love.draw()
 		love.graphics.print(test1 .. " * " .. test2 .. " = " .. test1 * test2,300,300)
 	end
 	love.graphics.print("argh: " .. (argh or "[nil]"),300,340)
-	
-	debugUI.draw()
-end
-
-function love.mousepressed(x, y, button)
-	debugUI.mousepressed(x, y, button)
-end
-
-function love.mousereleased(x, y, button)
-	debugUI.mousereleased(x, y, button)
 end
 
 function love.keypressed(key, unicode)
 	if key == "escape" then love.event.push("quit") end
-	debugUI.keypressed(key, unicode)
-end
-
-function love.keyreleased(key)
-	debugUI.keyreleased(key)
 end


### PR DESCRIPTION
Added unobtrusive hooking functionality via the debugUI.hookCallbacks() function. It replaces each of the required love callback functions (love.update, love.draw et cetera) by a wrapper that first calls the original callback function (if any,) preserving parameters and return values exactly, and then calls the debugUI handler afterwards. Tested with love 0.9.1